### PR TITLE
Fixed Database Date Format

### DIFF
--- a/src/data_processing/Scraping.py
+++ b/src/data_processing/Scraping.py
@@ -459,6 +459,12 @@ def upload_to_database(df, table_name, connection):
             if_exists="replace",
             index=False
         )
+        cursor = connection.cursor()
+        # Fixes the date format in the database directly; removes the seconds
+        cursor.execute(f'''
+            UPDATE {table_name}
+            SET title_metadata_last_modified = strftime('%Y-%m-%d', title_metadata_last_modified)
+        ''')
         connection.commit()
     except Exception as e:
         # Rollback in case of error


### PR DESCRIPTION
Tried several ways of modifying the format before the data is inserted to the DB, but no matter what it insisted on adding the seconds at the end which was odd, so instead I just opted to reformat it afterwards.
Not the most elegant solution, but it seems to work fine (tested with local files too).